### PR TITLE
Fix ACK handling after data file is received

### DIFF
--- a/lpr_daemon.go
+++ b/lpr_daemon.go
@@ -880,7 +880,7 @@ func (lpr *LprConnection) addToFile(data []uint8) (bool, error) {
 
 	// Here we force the binary 0 to be there after the data (which is the sender's part of ACK)
 	if data[len(data)-1] == 0 && (lpr.Filesize == 0 || (lpr.processedDataBytes+uint64(len(data)-1) >= lpr.Filesize)) {
-		// This is the last block and we implicetly read the 0 byte -> cut it away...
+		// This is the last block and we implicitly read the 0 byte -> cut it away...
 		data = data[:len(data)-1]
 		end = true
 	}

--- a/lpr_daemon_test.go
+++ b/lpr_daemon_test.go
@@ -2,6 +2,7 @@ package lprlib
 
 import (
 	"fmt"
+	"io"
 	"io/fs"
 	"io/ioutil"
 	"log"
@@ -653,4 +654,61 @@ func TestCheckForUTF8StringEncoding(t *testing.T) {
 			require.Equal(t, tt.result, result)
 		})
 	}
+}
+
+func TestDaemonMustNotCloseConnection(t *testing.T) {
+	SetDebugLogger(log.Print)
+	var err error
+	var out []byte
+	var name string
+
+	port := uint16(2345)
+
+	text := "Text for the file"
+	name, err = generateTempFile("", "", text)
+	require.Nil(t, err)
+
+	fmt.Println("Tempfile:", name)
+
+	var lprd LprDaemon
+	var lprs LprSend
+
+	err = lprd.Init(port, "")
+	require.Nil(t, err)
+
+	file, err := os.Open(name)
+	require.Nil(t, err)
+	defer file.Close()
+
+	// send file with correct size
+	err = lprs.Init("127.0.0.1", name, port, "raw", "TestUser", time.Minute)
+	require.Nil(t, err)
+
+	err = lprs.sendFile(file, int64(len(text)))
+	require.Nil(t, err)
+	err = lprs.SendConfiguration()
+	require.Nil(t, err)
+
+	time.Sleep(1 * time.Second)
+
+	one := make([]byte, 1)
+	lprs.socket.SetReadDeadline(time.Now().Add(1 * time.Second))
+
+	if _, err := lprs.socket.Read(one); err == io.EOF {
+		t.Error("Daemon closed the connection")
+	}
+
+	err = lprs.Close()
+	require.Nil(t, err)
+
+	con := <-lprd.FinishedConnections()
+	require.Equal(t, End, con.Status)
+	out, err = ioutil.ReadFile(con.SaveName)
+	require.Nil(t, err)
+	err = os.Remove(con.SaveName)
+	require.Nil(t, err)
+	require.Equal(t, text, string(out))
+
+	lprd.Close()
+	os.Remove(name)
 }

--- a/lpr_daemon_test.go
+++ b/lpr_daemon_test.go
@@ -484,8 +484,8 @@ func TestDaemonFileSize(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, text, string(out))
 
-	// send file with incorrect size greater than 2GB
-	err = lprs.Init("127.0.0.1", name, port, "raw", "TestUser", time.Minute)
+	// send file with too small size
+	err = lprs.Init("127.0.0.1", name, port, "raw", "TestUser", time.Second*2)
 	require.Nil(t, err)
 
 	err = lprs.SendConfiguration()
@@ -493,7 +493,7 @@ func TestDaemonFileSize(t *testing.T) {
 
 	_, err = file.Seek(0, 0)
 	require.Nil(t, err)
-	err = lprs.sendFile(file, 1024*1024*1024*1024)
+	err = lprs.sendFile(file, 1)
 	require.Nil(t, err)
 	err = lprs.Close()
 	require.Nil(t, err)

--- a/lpr_send.go
+++ b/lpr_send.go
@@ -414,11 +414,6 @@ func (lpr *LprSend) sendFile(reader io.Reader, fileSize int64) error {
 			size = uint64(rsize)
 		}
 
-		if size < lpr.MaxSize {
-			fileBuffer[size] = 0
-			size++
-		}
-
 		_, err = lpr.writeByte(fileBuffer[:size])
 		if err != nil {
 			return &LprError{"PRINTER_ERROR: " + err.Error()}
@@ -430,6 +425,11 @@ func (lpr *LprSend) sendFile(reader io.Reader, fileSize int64) error {
 		// logDebugf("Send file part: Position=%d, Size=%5d (%2.2f%%)", position, size, percent)
 	}
 	logDebug("File sent")
+
+	_, err = lpr.writeByte([]byte{0})
+	if err != nil {
+		return &LprError{"PRINTER_ERROR: Error sending end-of-data zero byte: " + err.Error()}
+	}
 
 	/*
 	 * Receive answer ( 0 if there wasn't an error )


### PR DESCRIPTION
This fixes an error if the control file is delivered after the data file and a file size was specified when sending the data file and the ending zero byte (sent by the client) comes in an own package.