### PR TITLE
Improved handling of negative data file sizes

### DIFF
--- a/lpr_daemon_test.go
+++ b/lpr_daemon_test.go
@@ -526,6 +526,28 @@ func TestDaemonFileSize(t *testing.T) {
 	err = os.Remove(con.SaveName)
 	require.Nil(t, err)
 
+	// send file with negative size
+	err = lprs.Init("127.0.0.1", name, port, "raw", "TestUser", time.Second*2)
+	require.Nil(t, err)
+
+	err = lprs.SendConfiguration()
+	require.Nil(t, err)
+
+	_, err = file.Seek(0, 0)
+	require.Nil(t, err)
+	err = lprs.sendFile(file, -1024)
+	require.Nil(t, err)
+	err = lprs.Close()
+	require.Nil(t, err)
+
+	con = <-lprd.FinishedConnections()
+	require.Equal(t, End, con.Status)
+	out, err = os.ReadFile(con.SaveName)
+	require.Nil(t, err)
+	err = os.Remove(con.SaveName)
+	require.Nil(t, err)
+	require.Equal(t, text, string(out))
+
 	time.Sleep(time.Second)
 
 	lprd.Close()


### PR DESCRIPTION
LPR connections transmitting negative data file sizes will no longer be aborted, but instead will be treated the same as a data file size of zero.